### PR TITLE
fix: Remove juzu from meeds-io - meeds-io#MIPs#70

### DIFF
--- a/extension/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/extension/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -3,5 +3,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_resources_1_3 http://www.gatein.org/xml/ns/gatein_resources_1_3"
     xmlns="http://www.gatein.org/xml/ns/gatein_resources_1_3">
+    <module>
+      <name>juzu-ajax</name>
+      <as>jzAjax</as>
+      <script>
+          <path>/js/script.js</path>
+      </script>
+      <depends>
+          <module>jquery</module>
+          <as>jQuery</as>
+      </depends>
+    </module>
 </gatein-resources>
 

--- a/extension/src/main/webapp/js/script.js
+++ b/extension/src/main/webapp/js/script.js
@@ -1,0 +1,43 @@
+(function($) {
+    $.fn.jz = function() {
+      return this.closest(".jz");
+    };
+    $.fn.jzURL = function(mid) {
+      return this.
+        jz().
+        children().
+        filter(function() { return $(this).data("method-id") == mid; }).
+        map(function() { return $(this).data("url"); })[0];
+    };
+    var re = /^(.*)\(\)$/;
+    $.fn.jzAjax = function(url, options) {
+      if (typeof url === "object") {
+        options = url;
+        url = options.url;
+      }
+      var match = re.exec(url);
+      if (match != null) {
+        url = this.jzURL(match[1]);
+        if (url != null) {
+          options = $.extend({}, options || {});
+          options.url = url;
+          return $.ajax(options);
+        }
+      }
+    };
+    $.fn.jzLoad = function(url, data, complete) {
+      var match = re.exec(url);
+      if (match != null) {
+        var repl = this.jzURL(match[1]);
+        url = repl || url;
+      }
+      if (typeof data === "function") {
+        complete = data;
+        data = null;
+      }
+      return this.load(url, data, complete);
+    };
+    $.fn.jzFind = function(arg) {
+      return this.jz().find(arg);
+    }
+})(jQuery);

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>addons-parent-pom</artifactId>
+    <artifactId>addons-exo-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
-    <version>14-M15</version>
+    <version>17-M04</version>
   </parent>
   <groupId>org.exoplatform.addons.rh-management</groupId>
   <artifactId>rh-management</artifactId>
@@ -25,25 +25,18 @@
   </scm>
   <properties>
     <juzu.jackson.version>1.2.0</juzu.jackson.version>
-    <org.exoplatform.commons.version>6.3.x-SNAPSHOT</org.exoplatform.commons.version>
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
-    <addon.exo.jcr.version>6.3.x-SNAPSHOT</addon.exo.jcr.version>
-    <addon.exo.agenda.version>1.2.x-SNAPSHOT</addon.exo.agenda.version>
+    <org.exoplatform.commons-exo.version>6.5.x-SNAPSHOT</org.exoplatform.commons-exo.version>
+    <org.exoplatform.social.version>6.5.x-exo-SNAPSHOT</org.exoplatform.social.version>
+    <addon.exo.jcr.version>6.5.x-SNAPSHOT</addon.exo.jcr.version>
+    <addon.exo.agenda.version>1.4.x-SNAPSHOT</addon.exo.agenda.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <!-- Import versions from platform project -->
       <dependency>
-        <groupId>org.exoplatform.commons</groupId>
-        <artifactId>commons-api</artifactId>
-        <version>${org.exoplatform.commons.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.commons</groupId>
-        <artifactId>commons-component-common</artifactId>
-        <version>${org.exoplatform.commons.version}</version>
+        <groupId>org.exoplatform.commons-exo</groupId>
+        <artifactId>commons-juzu</artifactId>
+        <version>${org.exoplatform.commons-exo.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/portlet/pom.xml
+++ b/portlet/pom.xml
@@ -20,7 +20,7 @@
 			<artifactId>rh-management-component</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.exoplatform.commons</groupId>
+			<groupId>org.exoplatform.commons-exo</groupId>
 			<artifactId>commons-juzu</artifactId>
 			<scope>provided</scope>
 		</dependency>


### PR DESCRIPTION
Juzu dependency is deprecated in meeds.
We still need it for chat, rh-management and customer space.
We move it in eXo side waiting the refactor of these components.